### PR TITLE
Issue status

### DIFF
--- a/src/components/UsernameForm/CheckButton.js
+++ b/src/components/UsernameForm/CheckButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const CheckButton = () => (
   <button
-    className="bn br--right bg-teal-lighter text-pink-darkest rounded-r-sm px-4 pointer text-white"
+    className="bn br--right bg-blue-light rounded-r-sm px-4 pointer text-blue-darker"
     type="submit"
   >
     Check

--- a/src/pages/User/components/PullRequests/MeLinkInfo.js
+++ b/src/pages/User/components/PullRequests/MeLinkInfo.js
@@ -13,7 +13,7 @@ export default class MeLinkInfo extends Component {
   render = () => (
     <div className="rounded mx-auto mt-16 overflow-hidden w-5/6 lg:w-1/2 mt-4">
       <button
-        className="bg-teal-lighter text-pink-darkest mx-auto mt-2 h-8 border-none pointer rounded-sm px-4 block saveUser"
+        className="bg-blue-light text-blue-darker mx-auto mt-2 h-8 border-none pointer rounded-sm px-4 block saveUser"
         onClick={this.storeUsernameAsMe}
         style={buttonStyle}
       >

--- a/src/pages/User/components/PullRequests/PullRequest/index.js
+++ b/src/pages/User/components/PullRequests/PullRequest/index.js
@@ -3,13 +3,22 @@ import PropTypes from 'prop-types';
 import MergeStatus from './MergeStatus';
 import PullRequestInfo from './PullRequestInfo';
 
+const ISSUE_STATUS = {
+  ALL: 'all',
+  OPEN: 'open',
+  CLOSED: 'closed'
+};
+
 const PullRequest = ({ pullRequest }) => (
   <div
     className={`bg-white leading-normal ${
       pullRequest.has_hacktoberfest_label ? 'hacktoberfest' : ''
     }p-4 flex border-b border-grey break-words`}
   >
-    <MergeStatus open={pullRequest.open} merged={pullRequest.merged} />
+    <MergeStatus
+      open={pullRequest.state === ISSUE_STATUS.OPEN}
+      merged={pullRequest.state === ISSUE_STATUS.CLOSED}
+    />
     <PullRequestInfo pullRequest={pullRequest} />
   </div>
 );


### PR DESCRIPTION
The issue status was always showing closed. The github API changed to include `state` instead of `open` and `merged` flags. So, added a check for the `state` prop.

**BEFORE:**
<img width="1097" alt="before" src="https://user-images.githubusercontent.com/4490749/66983876-553ad800-f0d9-11e9-9310-e0b2a8ec6ee1.png">


**AFTER:**
<img width="1156" alt="after" src="https://user-images.githubusercontent.com/4490749/66983905-62f05d80-f0d9-11e9-993a-cf049ced2855.png">
