### PR TITLE
Fixed punctuation error in PRs should not be labeled as invalid

### DIFF
--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -188,7 +188,7 @@ const Home = () => {
               <div className="col-12 col-md-6 col-lg-3">
                 <div className="card participation-card">
                   <img className='mb-md-6x' src={Icon7} alt="PRs should not be labeled as ‘invalid." />
-                  <p className='leading-6 font-normal'>PRs should not be labeled as ‘invalid.&apos;</p>
+                  <p className='leading-6 font-normal'>PRs should not be labeled as ‘invalid&apos;.</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# Description
Fixed punctuation error in PRs should not be labeled as invalid

# Testing Evidence

## Before
<img width="1454" alt="Screenshot 2024-10-19 at 1 06 46 PM" src="https://github.com/user-attachments/assets/0d72c65f-34b8-41b6-a85b-988d46bc13f5">

## After
<img width="1492" alt="Screenshot 2024-10-19 at 12 55 39 PM" src="https://github.com/user-attachments/assets/cfc5fb08-fd13-4416-8dd5-0a82282a3c5a">

